### PR TITLE
Feat: displays admin dashboard header

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,6 +272,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-21
   x86_64-linux

--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -1,0 +1,5 @@
+class Admin::DashboardsController < ApplicationController
+    def index
+        
+    end
+end

--- a/app/views/admin/dashboards/index.html.erb
+++ b/app/views/admin/dashboards/index.html.erb
@@ -1,0 +1,1 @@
+<h1>Admin Dashboard</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,9 +4,10 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "articles#index"
   resources :merchants, only: [] do
-    resource :dashboard, only: [:show]
+    resources :dashboard, only: [:show]
     resources :items, only: [:index]
     resources :invoices, only: [:index]
   end
 
+ resources :admin, controller: "admin/dashboards", only: :index
 end

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin dashboard' do
+    describe 'User story 19' do
+        it 'displays admin dashboard header' do
+            # As an admin,
+            # When I visit the admin dashboard (/admin)
+            visit "/admin"
+            # Then I see a header indicating that I am on the admin dashboard
+            expect(page).to have_content("Admin Dashboard")
+        end
+    end
+end


### PR DESCRIPTION
As an admin,
When I visit the admin dashboard (/admin)
Then I see a header indicating that I am on the admin dashboard