### PR TITLE
feat:US32

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb

--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -1,4 +1,9 @@
 class Admin::InvoicesController < ApplicationController
     def index 
+        @invoices = Invoice.all
+    end
+
+    def show
+        @invoice = Invoice.find(params[:id])
     end
 end

--- a/app/views/admin/invoices/index.html.erb
+++ b/app/views/admin/invoices/index.html.erb
@@ -1,0 +1,4 @@
+<h1>Admin Invoices</h1>
+<%@invoices.each do |invoice|%>
+<%= link_to invoice.id, "/admin/invoices/#{invoice.id}"%>
+<%end%>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,0 +1,2 @@
+<h1> Admin Invoice Info</h1>
+<h3><%=@invoice.id%></h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,6 @@ Rails.application.routes.draw do
   namespace :admin do
     get "/", to: "dashboards#index"
     resources :merchants, only: [:index, :show]
-    resources :invoices, only: :index
+    resources :invoices, only: [:index, :show]
   end
 end

--- a/spec/features/admin/invoices/index_spec.rb
+++ b/spec/features/admin/invoices/index_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin Invoices Index' do
+    describe 'User story 32' do
+        before do
+            @nico = Customer.create!(first_name: "Nico", last_name: "Shantii")
+            @wolf = Customer.create!(first_name: "Wolf", last_name: "Goode")
+            @invoice_1 = Invoice.create!(status: "Not Paid", customer_id: @nico.id)
+            @invoice_2 = Invoice.create!(status: "Paid", customer_id: @nico.id)
+        end
+
+        it 'shows a clickable list of all invoice ids in the system' do
+            #As an admin,
+            #When I visit the admin Invoices index (/admin/invoices)
+            visit admin_invoices_path
+            # Then I see a list of all Invoice ids in the system
+            expect(page).to have_content(@invoice_1.id.to_s)
+            expect(page).to have_content(@invoice_2.id.to_s)
+            # Each id links to the admin invoice show page
+            expect(page).to have_link(@invoice_1.id.to_s)
+            expect(page).to have_link(@invoice_2.id.to_s)
+
+            click_link(@invoice_1.id.to_s)
+            expect(current_path).to eq(admin_invoice_path(@invoice_1))
+            
+            visit admin_invoices_path
+            
+            click_link(@invoice_2.id.to_s)
+            expect(current_path).to eq(admin_invoice_path(@invoice_2))
+        end
+    end
+end


### PR DESCRIPTION
user story 32 - Admin Invoices Index Page
As an admin,
When I visit the admin Invoices index (/admin/invoices)
Then I see a list of all Invoice ids in the system
Each id links to the admin invoice show page

Created admin invoice index_spec, added index and show logic to admin invoices_controller, added to the route for invoices show, created invoices index view with clickable links, and started invoices show (i dont think that was necessary...yet, as i am not testing for anything to be there, just that the index links take me there) but i added a little anyway. 