### PR TITLE
feat/US33, shows invoice info - invoice id, status, invoice created_a…

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -5,4 +5,8 @@ class Invoice < ApplicationRecord
   has_many :items, through: :invoice_items
 
   validates :status, presence: true
+
+  def formatted_created_at
+    created_at.strftime('%A, %B %d, %Y')
+  end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,2 +1,6 @@
 <h1> Admin Invoice Info</h1>
-<h3><%=@invoice.id%></h3>
+<h3>Invoice ID: <%=@invoice.id%></h3>
+<h3>Status: <%=@invoice.status%></h3>
+<h3>Created At: <%=@invoice.formatted_created_at%></h3>
+<h3>Customer First Name: <%=@invoice.customer.first_name%></h3>
+<h3>Customer Last Name: <%=@invoice.customer.last_name%></h3>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin Invoices Show Page' do
+    describe 'User Story 33' do
+        before do
+            @nico = Customer.create!(first_name: "Nico", last_name: "Shantii")
+            @wolf = Customer.create!(first_name: "Wolf", last_name: "Goode")
+            @invoice_1 = Invoice.create!(status: "Not Paid", customer_id: @nico.id)
+            @invoice_2 = Invoice.create!(status: "Paid", customer_id: @nico.id)
+        end
+
+        it 'shows invoice info - invoice id, status, invoice created_at date (Week-Day, Month dd, yyyy), customer first and last name' do
+            # As an admin,
+            # When I visit an admin invoice show page (/admin/invoices/:invoice_id)
+            visit admin_invoice_path("#{@invoice_1.id}")
+            # Then I see information related to that invoice including:
+            # Invoice id
+            expect(page).to have_content("Invoice ID: #{@invoice_1.id}")
+            # Invoice status
+            expect(page).to have_content("Status: #{@invoice_1.status}")
+            # Invoice created_at date in the format "Monday, July 18, 2019"
+            expect(page).to have_content("Created At: #{@invoice_1.formatted_created_at}")
+            # Customer first and last name
+            nico = Customer.find(@invoice_1.customer_id)
+            expect(page).to have_content("Customer First Name: #{nico.first_name}")
+            expect(page).to have_content("Customer Last Name: #{nico.last_name}")
+            expect(page).to_not have_content("Wolf")
+        end
+    end
+end


### PR DESCRIPTION
Show page for any specific admin invoice's information:
shows invoice info - invoice id, status, invoice created_at date (Week-Day, Month dd, yyyy), customer first and last name.

I added a model method in the invoice model in order to format the date like the story asks and keeping the logic where it should be. made admin/invoice_spec file, admin/invoices/show.html.erb. Is this a sad path statement? expect(page).to_not have_content("Wolf") Wolf should not come up as that is a name for invoice_2. Also, was it ok to put this logic in the test so i can show the specific invoices customer first and last name?  
# Customer first and last name
            nico = Customer.find(@invoice_1.customer_id)
            expect(page).to have_content("Customer First Name: #{nico.first_name}")
            expect(page).to have_content("Customer Last Name: #{nico.last_name}")