### PR TITLE
Feat/us21 - Admin dashboard top 5 customers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,6 +272,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-21
   x86_64-linux

--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -1,4 +1,6 @@
 class Admin::DashboardsController < ApplicationController
     def index
+        # require'pry';binding.pry
+        @top_customers = Merchant.top_customers
     end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -25,4 +25,14 @@ class Merchant < ApplicationRecord
       .limit(5)
       .select("customers.*", "COUNT(transactions.id) AS transaction_count")
   end
+
+  def self.top_customers
+    Customer
+      .joins(:transactions)
+      .where(transactions: { result: "success" })
+      .group("customers.id")
+      .order("count(transactions.id) DESC")
+      .limit(5)
+      .select("customers.*", "COUNT(transactions.id) AS transaction_count")
+  end
 end

--- a/app/views/admin/dashboards/index.html.erb
+++ b/app/views/admin/dashboards/index.html.erb
@@ -1,4 +1,12 @@
-<h1>Admin Dashboard</h1>
-
+<h1>Little Etsy Shop Admin Dashboard</h1>
 <%= link_to "Merchants", admin_merchants_path %>
 <%= link_to "Invoices", admin_invoices_path %>
+
+<h3>Little Etsy's Favorite Customers</h3>
+    <ol>
+        <% @top_customers.each do |top_customer| %>
+            <section id="top_customer-<%= top_customer.id %>">
+            <li> <%= "#{top_customer.first_name} #{top_customer.last_name}: #{top_customer.transaction_count} transactions" %></li>
+        <% end %>
+    </ol>
+            </section>

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -1,13 +1,33 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin dashboard' do
+    let(:merchant) { FactoryBot.create(:merchant) }
+    let(:item) { FactoryBot.create(:item, merchant: merchant) }
+    let(:top_customers) { FactoryBot.create_list(:customer, 5) }
+    let(:customers) { FactoryBot.create_list(:customer, 5) }
+
+    before do
+        top_customers.each do |customer|
+          invoice = FactoryBot.create(:invoice, customer: customer)
+          invoice.items = [item]
+          FactoryBot.create_list(:transaction, Random.rand(2..5), invoice: invoice)
+          invoice.save!
+        end
+        customers.each do |customer|
+          invoice = FactoryBot.create(:invoice, customer: customer)
+          invoice.items = [item]
+          FactoryBot.create_list(:transaction, 1, invoice: invoice)
+          invoice.save!
+        end
+    end
+
     describe 'User story 19' do
         it 'displays admin dashboard header' do
             # As an admin,
             # When I visit the admin dashboard (/admin)
             visit admin_path
             # Then I see a header indicating that I am on the admin dashboard
-            expect(page).to have_content("Admin Dashboard")
+            expect(page).to have_content("Little Etsy Shop Admin Dashboard")
         end
     end
 
@@ -20,6 +40,26 @@ RSpec.describe 'Admin dashboard' do
             expect(page).to have_link("Merchants", href: admin_merchants_path)
             # And I see a link to the admin invoices index (/admin/invoices)
             expect(page).to have_link("Invoices", href: admin_invoices_path)
+        end
+    end
+
+    describe 'User Story 21' do
+        
+        it 'displays top 5 customers and count of successful transactions' do
+            # As an admin,
+            # When I visit the admin dashboard (/admin)
+            visit admin_path
+            # Then I see the names of the top 5 customers
+            # who have conducted the largest number of successful transactions
+            # And next to each customer name I see the number of successful transactions they have
+            # conducted
+            expect(page).to have_content("Little Etsy's Favorite Customers")
+
+            top_customers.each do |top_customer|
+                within "#top_customer-#{top_customer.id}" do
+                    expect(page).to have_content("#{top_customer.first_name} #{top_customer.last_name}: #{top_customer.transactions.count} transactions")
+                end
+            end
         end
     end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -37,4 +37,32 @@ RSpec.describe Merchant, type: :model do
       expect(merchant.top_customers).to match_array(top_customers)
     end
   end
+
+  describe 'class methods' do
+    let(:merchant) { FactoryBot.create(:merchant) }
+    let(:item) { FactoryBot.create(:item, merchant: merchant) }
+    let(:top_customers) { FactoryBot.create_list(:customer, 5) }
+    let(:customers) { FactoryBot.create_list(:customer, 5) }
+
+    before do
+      top_customers.each do |customer|
+        invoice = FactoryBot.create(:invoice, customer: customer)
+        invoice.items = [item]
+        FactoryBot.create_list(:transaction, Random.rand(2..5), invoice: invoice)
+        invoice.save!
+      end
+      customers.each do |customer|
+        invoice = FactoryBot.create(:invoice, customer: customer)
+        invoice.items = [item]
+        FactoryBot.create_list(:transaction, 1, invoice: invoice)
+        invoice.save!
+      end
+    end
+
+    describe '#self.top_customers' do
+      it 'returns the top 5 customers out of ALL customers with their success transactions counts in descending order' do
+        expect(Merchant.top_customers).to match_array(top_customers)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Had to add a model method to the merchant model to retrieve top 5 customers OVERALL and not just for a specific merchant.

Admin Dashboard Statistics - Top Customers
As an admin,
When I visit the admin dashboard (/admin)
Then I see the names of the top 5 customers
who have conducted the largest number of successful transactions
And next to each customer name I see the number of successful transactions they have
conducted