### PR TITLE
User Story 36

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -7,4 +7,17 @@ class Admin::InvoicesController < ApplicationController
     def show
         @invoice = Invoice.find(params[:id])
     end
+
+    def update
+        @invoice = Invoice.find(params[:id])
+        if @invoice.update(invoice_params)
+            redirect_to admin_invoice_path(@invoice)
+        end
+    end
+
+    private
+
+    def invoice_params
+        params.require(:invoice).permit(:status)
+    end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -11,10 +11,17 @@
                     <h4><%= invoice_item.item.name %></h4>
                     <li>Quantity: <%=invoice_item.quantity%></li>
                     <li>Unit price: <%=number_to_currency(invoice_item.unit_price)%></li>
-                    <li>Status: <%=invoice_item.status%></li>
+                    <li>Item Status: <%=invoice_item.status%></li>
                 </section>
         <% end %>
     </ul>
+
+
+    <%= form_with model: [:admin, @invoice], method: :patch do |f| %>
+                        <%= f.label :status, "Invoice Status" %>
+                        <%= f.select :status, [["In Progress", "in_progress"], ["Cancelled", "cancelled"], ["Completed", "completed"]] %>
+                        <%= f.submit "Update Invoice Status" %>
+                    <% end %>
 
 
 <h3>Total Revenue: <%=number_to_currency(@invoice.total_revenue)%></h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,6 @@ Rails.application.routes.draw do
   namespace :admin do
     get "/", to: "dashboards#index"
     resources :merchants, only: [:index, :show, :edit, :update]
-    resources :invoices, only: [:index, :show]
+    resources :invoices, only: [:index, :show, :update]
   end
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -71,19 +71,19 @@ RSpec.describe 'Admin invoice show page' do
                 # - The price the Item sold for
                 expect(page).to have_content("Unit price: $20.00 ")
                 # - The Invoice Item status
-                expect(page).to have_content("Status: pending")
+                expect(page).to have_content("Item Status: pending")
             end
             within "#invoice_item-#{invoice_item_2.id}" do
                 expect(page).to have_content(item_2.name)
                 expect(page).to have_content("Quantity: 3")
                 expect(page).to have_content("Unit price: $15.00 ")
-                expect(page).to have_content("Status: packaged")
+                expect(page).to have_content("Item Status: packaged")
             end
             within "#invoice_item-#{invoice_item_3.id}" do
                 expect(page).to have_content(item_3.name)
                 expect(page).to have_content("Quantity: 1")
                 expect(page).to have_content("Unit price: $25.00 ")
-                expect(page).to have_content("Status: shipped")
+                expect(page).to have_content("Item Status: shipped")
             end
             
             visit admin_invoice_path(invoice_3)
@@ -92,14 +92,14 @@ RSpec.describe 'Admin invoice show page' do
                 expect(page).to have_content(item_3.name)
                 expect(page).to have_content("Quantity: 4")
                 expect(page).to have_content("Unit price: $25.00 ")
-                expect(page).to have_content("Status: pending")
+                expect(page).to have_content("Item Status: pending")
             end
             
             within "#invoice_item-#{invoice_item_8.id}" do
                 expect(page).to have_content(item_3.name)
                 expect(page).to have_content("Quantity: 1")
                 expect(page).to have_content("Unit price: $25.00 ")
-                expect(page).to have_content("Status: packaged")
+                expect(page).to have_content("Item Status: packaged")
             end
         end
     end
@@ -136,5 +136,47 @@ RSpec.describe 'Admin invoice show page' do
             visit admin_invoice_path(invoice_2)
             expect(page).to have_content("Total Revenue: $180.00")
         end       
+    end
+
+
+    describe 'User story 36' do
+        let(:merchant) { FactoryBot.create(:merchant) }
+        let(:item_1) { FactoryBot.create(:item, merchant: merchant) }
+        let(:item_2) { FactoryBot.create(:item, merchant: merchant) }
+        let(:item_3) { FactoryBot.create(:item, merchant: merchant) }
+        let(:customer) { FactoryBot.create(:customer) }
+        it 'displays invoice status as a select field and can be updated by toggling the select field to chosen status' do
+            invoice_1 = FactoryBot.create(:invoice, customer: customer)
+            invoice_2 = FactoryBot.create(:invoice, customer: customer, status: 1)
+            invoice_3 = FactoryBot.create(:invoice, customer: customer, status: 0)
+
+            invoice_item_1 = InvoiceItem.create!(invoice: invoice_1, quantity: 2, unit_price: 20, item: item_1, status: 0)
+            invoice_item_2 = InvoiceItem.create!(invoice: invoice_1, quantity: 3, unit_price: 15, item: item_2, status: 1)
+            invoice_item_3 = InvoiceItem.create!(invoice: invoice_1, quantity: 1, unit_price: 25, item: item_3, status: 2)
+
+            invoice_item_4 = InvoiceItem.create!(invoice: invoice_2, quantity: 4, unit_price: 15, item: item_2, status: 0)
+            invoice_item_5 = InvoiceItem.create!(invoice: invoice_2, quantity: 3, unit_price: 15, item: item_2, status: 1)
+            invoice_item_6 = InvoiceItem.create!(invoice: invoice_2, quantity: 3, unit_price: 25, item: item_3, status: 2)
+            
+            invoice_item_7 = InvoiceItem.create!(invoice: invoice_3, quantity: 4, unit_price: 25, item: item_3, status: 0)
+            invoice_item_8 = InvoiceItem.create!(invoice: invoice_3, quantity: 1, unit_price: 25, item: item_3, status: 1)
+            # As an admin     
+            # When I visit an admin invoice show page (/admin/invoices/:invoice_id)
+            visit admin_invoice_path(invoice_3)
+            # I see the invoice status is a select field
+            expect(page).to have_select("Status", options: ["In Progress", "Cancelled", "Completed"])
+            # And I see that the invoice's current status is selected
+            expect(page).to have_select("Status", selected: "In Progress")
+            # When I click this select field,
+            # Then I can select a new status for the Invoice,
+            select "Cancelled", from: "invoice_status"
+            # And next to the select field I see a button to "Update Invoice Status"
+            # When I click this button
+            click_on "Update Invoice Status"
+            # I am taken back to the admin invoice show page
+            expect(current_path).to eq(admin_invoice_path(invoice_3))
+            # And I see that my Invoice's status has now been updated
+            expect(page).to have_content("Cancelled")
+        end
     end
 end


### PR DESCRIPTION
36. Admin Invoice Show Page: Update Invoice Status

As an admin     
When I visit an admin invoice show page (/admin/invoices/:invoice_id)
I see the invoice status is a select field
And I see that the invoice's current status is selected
When I click this select field,
Then I can select a new status for the Invoice,
And next to the select field I see a button to "Update Invoice Status"
When I click this button
I am taken back to the admin invoice show page
And I see that my Invoice's status has now been updated